### PR TITLE
fix: Transparency when loading a theme for nth time

### DIFF
--- a/lua/base46/base46_hls.lua
+++ b/lua/base46/base46_hls.lua
@@ -8,6 +8,13 @@ function M.get_hls(colors, transparent)
 
     if transparent then
         table.insert(integrations, "glassy")
+    else
+        local integrations_copy = integrations
+        for i, integration in ipairs(integrations_copy) do
+            if integration == "glassy" then
+                table.remove(integrations, i)
+            end
+        end
     end
 
     for _, integration_module in ipairs(integrations) do


### PR DESCRIPTION
When loading the theme a second time using `require("base46").load_theme(opts)` you could set `transparency = true` but setting it to false if requiring the module again won't behave the expected way.

An example from my [config](https://github.com/AlejandroSuero/.config/blob/main/nvim/lua/aome/core/utils.lua):

```lua
--- Reloads the selected colorscheme
---@param colorscheme string Name of the colorscheme you want to reload
M.reload_colorscheme = function(colorscheme)
  vim.g.colorscheme = colorscheme
  require("base46").load_theme({
    theme = colorscheme,
    transparency = vim.g.transparency,
  })
end
```

Whenever a reload the colorscheme, if **transparency** goes from false to true it works, not the other way if doing it again, if restarting nvim, it does work by the reverse way.

The problem is the integrations is kept in its final state of adding `glassy`.

Another way of fixing this problem may be using `plenary.reload` but this will add a dependency.